### PR TITLE
[MainBoard] 차트 디자인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "0-crypto-meter-techno-leaders",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.3.0",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
@@ -892,6 +894,11 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1271,6 +1278,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.3.0.tgz",
+      "integrity": "sha512-ynG0E79xGfMaV2xAHdbhwiPLczxnNNnasrmPEXriXsPJGjmhOBYzFVEsB65w2qMDz+CaBJJuJD0inE/ab/h36g==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=7"
       }
     },
     "node_modules/color-convert": {
@@ -3362,6 +3380,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "chart.js": "^4.3.0",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {

--- a/src/components/CoinChart.jsx
+++ b/src/components/CoinChart.jsx
@@ -11,7 +11,7 @@ import {
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
 
-function convetToChartData(data) {
+function convertToChartData(data) {
   const chartData = [];
   data.forEach((elem) => {
     const formattedDate = millisecondsToDate(elem[0]);
@@ -81,7 +81,7 @@ const getChartData = (canvas, data) => {
         borderWidth: 2,
         pointHoverBackgroundColor: '#00A661',
         pointHoverBorderWidth: 3,
-        data: convetToChartData(data),
+        data: convertToChartData(data),
       },
     ],
   };

--- a/src/components/CoinChart.jsx
+++ b/src/components/CoinChart.jsx
@@ -1,0 +1,133 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Filler,
+  Legend,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+function convetToChartData(data) {
+  const chartData = [];
+  data.forEach((elem) => {
+    const formattedDate = millisecondsToDate(elem[0]);
+    const price = Math.round(elem[1]);
+    chartData.push({ x: formattedDate, y: price });
+  });
+  return chartData;
+}
+
+function millisecondsToDate(milliseconds) {
+  const date = new Date(milliseconds);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const formattedDate = `${year}년 ${month}월 ${day}일`;
+  return formattedDate;
+}
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Filler,
+  Legend,
+  {
+    id: 'tooltipLine',
+    afterDraw: function (chart) {
+      if (chart.tooltip._active && chart.tooltip._active.length) {
+        const ctx = chart.ctx;
+        const activePoint = chart.tooltip._active[0];
+        const x = activePoint.element.x;
+        const topY = chart.scales.y.top;
+        const bottomY = chart.scales.y.bottom;
+        ctx.save();
+        ctx.beginPath();
+        ctx.setLineDash([5, 5]);
+        ctx.moveTo(x, topY);
+        ctx.lineTo(x, bottomY);
+        ctx.lineWidth = 1;
+        ctx.strokeStyle = '#262A38';
+        ctx.stroke();
+        ctx.restore();
+      }
+    },
+  }
+);
+
+const getChartData = (canvas, data) => {
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, 0, 411); // x0, y0, x1, y1 => 반응형이면 동적으로 height 값 prop으로 가져와야 할 듯
+  gradient.addColorStop(0, 'rgba(0, 166, 97, 0.3)');
+  gradient.addColorStop(0.5, 'rgba(9, 177, 76, 0.3)');
+  gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+  return {
+    datasets: [
+      {
+        pointRadius: 0,
+        fill: true,
+        backgroundColor: gradient,
+        borderColor: '#00A661',
+        borderWidth: 2,
+        pointHoverBackgroundColor: '#00A661',
+        pointHoverBorderWidth: 3,
+        data: convetToChartData(data),
+      },
+    ],
+  };
+};
+const options = {
+  responsive: true,
+  plugins: {
+    legend: {
+      position: false,
+    },
+    title: {
+      display: false,
+    },
+  },
+  intersection: {
+    mode: 'index',
+    intersect: false,
+  },
+  scales: {
+    x: {
+      grid: {
+        drawOnChartArea: false,
+      },
+      ticks: {
+        maxTicksLimit: 4,
+        callback: function (value) {
+          const label = this.getLabelForValue(value);
+          if (label.slice(-3) === ' 1일') {
+            return label.slice(0, -3);
+          }
+        },
+      },
+    },
+    y: {
+      ticks: {
+        callback: function (value) {
+          const label = this.getLabelForValue(value);
+          const deletedComma = label.replaceAll(',', '');
+          return `${deletedComma.slice(0, 1)},${deletedComma.slice(1, 4)}만`;
+        },
+      },
+    },
+  },
+};
+
+function CoinChart({ data }) {
+  const canvas = document.createElement('canvas');
+  const chartData = getChartData(canvas, data);
+  return <Line data={chartData} options={options} />;
+}
+
+export default CoinChart;

--- a/src/components/CoinChart.jsx
+++ b/src/components/CoinChart.jsx
@@ -46,12 +46,15 @@ ChartJS.register(
         const ctx = chart.ctx;
         const activePoint = chart.tooltip._active[0];
         const x = activePoint.element.x;
+        const y = activePoint.element.y;
         const topY = chart.scales.y.top;
         const bottomY = chart.scales.y.bottom;
         ctx.save();
         ctx.beginPath();
         ctx.setLineDash([5, 5]);
         ctx.moveTo(x, topY);
+        ctx.lineTo(x, y - 5);
+        ctx.moveTo(x, y + 5);
         ctx.lineTo(x, bottomY);
         ctx.lineWidth = 1;
         ctx.strokeStyle = '#262A38';
@@ -64,7 +67,7 @@ ChartJS.register(
 
 const getChartData = (canvas, data) => {
   const ctx = canvas.getContext('2d');
-  const gradient = ctx.createLinearGradient(0, 0, 0, 411); // x0, y0, x1, y1 => 반응형이면 동적으로 height 값 prop으로 가져와야 할 듯
+  const gradient = ctx.createLinearGradient(0, 0, 0, 411);
   gradient.addColorStop(0, 'rgba(0, 166, 97, 0.3)');
   gradient.addColorStop(0.5, 'rgba(9, 177, 76, 0.3)');
   gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
@@ -92,9 +95,17 @@ const options = {
     title: {
       display: false,
     },
+    tooltip: {
+      // position: 'topPosition',
+      displayColors: false,
+      callbacks: {
+        label: function (tooltipItem) {
+          return `￦${tooltipItem.formattedValue}`;
+        },
+      },
+    },
   },
-  intersection: {
-    mode: 'index',
+  interaction: {
     intersect: false,
   },
   scales: {

--- a/src/components/CoinChart.jsx
+++ b/src/components/CoinChart.jsx
@@ -53,7 +53,7 @@ ChartJS.register(
         ctx.beginPath();
         ctx.setLineDash([5, 5]);
         ctx.moveTo(x, topY);
-        ctx.lineTo(x, y - 5);
+        ctx.lineTo(x, y - 50);
         ctx.moveTo(x, y + 5);
         ctx.lineTo(x, bottomY);
         ctx.lineWidth = 1;
@@ -96,7 +96,7 @@ const options = {
       display: false,
     },
     tooltip: {
-      // position: 'topPosition',
+      yAlign: 'bottom',
       displayColors: false,
       callbacks: {
         label: function (tooltipItem) {

--- a/src/components/MainBoard.jsx
+++ b/src/components/MainBoard.jsx
@@ -1,0 +1,12 @@
+import CoinChart from '/src/components/CoinChart';
+import coinPrices from '/src/assets/coins_bitcoin_marketcharts.json';
+
+function MainBoard() {
+  return (
+    <div style={{ aspectRatio: 2 }}>
+      <CoinChart data={coinPrices.prices} />
+    </div>
+  );
+}
+
+export default MainBoard;


### PR DESCRIPTION
## 수행 내용
mock데이터 기준으로 차트 디자인을 작성했습니다.
- x, y축 라벨 커스텀
- 마우스 커서 위치에 따른 데이터 tooltip과 세로선 표시
- 반응형 사이즈
- mock 데이터의 입력으로 받은 ms 단위의 시간을 `xxxx년 xx월 xx일`로 변환

## 실행 화면
![K-008](https://github.com/codeit-bootcamp-frontend/0-crypto-meter-techno-leaders/assets/78773781/62c7dd05-c8ab-426e-9137-80382b73f78e)

## 미완성 기능
- 현재 mock데이터를 기준으로 작성된 로직입니다. 
ex) 금액이 천만 단위로 고정
- 추후 api로부터 받는 데이터에 따라 분기 로직 작성할 계획입니다.
